### PR TITLE
Added `SessionClosedException` exception in case of a connection shutdown

### DIFF
--- a/.github/actions/build_env/action.yml
+++ b/.github/actions/build_env/action.yml
@@ -10,7 +10,7 @@ inputs:
       required: false
       type: boolean
       default: false
-    
+
     poetry-virtualenvs-in-project:
       required: false
       type: boolean

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,11 +11,13 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      SENDGRID_API_KEY: SG.test123
     services:
         sendgrid:
           image: ghashange/sendgrid-mock:1.9.0
           env:
-            API_KEY: SG.test123
+            API_KEY: ${{ env.SENDGRID_API_KEY }}
           ports:
             - 3000:3000
     strategy:
@@ -40,6 +42,8 @@ jobs:
       
       - name: Run tests
         run: poetry run python -m pytest --cov=async_sendgrid
+        env:
+          SENDGRID_API_KEY: ${{ env.SENDGRID_API_KEY }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/README.md
+++ b/README.md
@@ -101,8 +101,3 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-- [SendGrid](https://sendgrid.com/) for their excellent email service
-- [httpx](https://www.python-httpx.org/) for the async HTTP client

--- a/async_sendgrid/exception.py
+++ b/async_sendgrid/exception.py
@@ -1,0 +1,7 @@
+class SessionClosedException(Exception):
+    """
+    Exception raised when the session is closed unexpectedly.
+    """
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(self.message)

--- a/async_sendgrid/exception.py
+++ b/async_sendgrid/exception.py
@@ -2,6 +2,7 @@ class SessionClosedException(Exception):
     """
     Exception raised when the session is closed unexpectedly.
     """
+
     def __init__(self, message: str):
         self.message = message
         super().__init__(self.message)

--- a/async_sendgrid/sendgrid.py
+++ b/async_sendgrid/sendgrid.py
@@ -31,8 +31,21 @@ class BaseSendgridAPI(ABC):
     def headers(self) -> dict[Any, Any]:
         """Not implemented"""
 
+    @property
+    @abstractmethod
+    def session(self) -> AsyncClient | None:
+        """Not implemented"""
+
     @abstractmethod
     async def send(self, message: Mail) -> Response:
+        """Not implemented"""
+
+    @abstractmethod
+    async def __aenter__(self) -> BaseSendgridAPI:
+        """Not implemented"""
+
+    @abstractmethod
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         """Not implemented"""
 
 
@@ -115,10 +128,16 @@ class SendgridAPI(BaseSendgridAPI):
         )
         return response
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> SendgridAPI:
         self._session = create_session(headers=self._headers)
         return self
 
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any):
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         assert self._session
         await self._session.aclose()
+
+    def __str__(self) -> str:
+        return f"SendGrid API Client\n  • Endpoint: {self._endpoint}\n"
+
+    def __repr__(self) -> str:
+        return f"SendgridAPI(endpoint={self._endpoint})"

--- a/async_sendgrid/sendgrid.py
+++ b/async_sendgrid/sendgrid.py
@@ -105,7 +105,9 @@ class SendgridAPI(BaseSendgridAPI):
         assert self._session
 
         if self._session.is_closed:
-            raise SessionClosedException("Session was closed, establishing new connection")
+            raise SessionClosedException(
+                "Session was closed, establishing new connection"
+            )
 
         json_message = message.get()
         response = await self._session.post(

--- a/docs/release-notes/v2.0.3.md
+++ b/docs/release-notes/v2.0.3.md
@@ -1,0 +1,17 @@
+# Release v2.0.3
+
+## Changes
+
+### API Improvements
+- Added session property to `SendgridAPI` for better awareness.
+- Improved type hints for async context manager methods in `SendgridAPI`.
+- Added a simplified session handling to the API along with introducing error handling.
+
+### Code Quality
+- Enhanced string representation of SendGrid API client for better readability.
+- Simplified string output to focus on essential information.
+- Maintained clear separation between `__str__` and `__repr__` methods.
+
+### Type Safety
+- Added explicit return type annotations for async context manager methods.
+- Improved type safety across the codebase.

--- a/tests/integration/test_sendgrid_client_integration.py
+++ b/tests/integration/test_sendgrid_client_integration.py
@@ -7,97 +7,90 @@ from async_sendgrid.exception import SessionClosedException
 from async_sendgrid.sendgrid import SendgridAPI
 
 
-class TestSendgridClient:
-
-    @pytest.fixture()
-    def client(self):
-        """Setup client"""
-        secret_key = os.environ["SENDGRID_API_KEY"]
-        impersonate_subuser = "John Smith"
-        endpoint = "http://localhost:3000/v3/mail/send"
-        client = SendgridAPI(
-            api_key=secret_key,
-            endpoint=endpoint,
-            impersonate_subuser=impersonate_subuser,
+@pytest.fixture
+def client():
+    """Setup client"""
+    secret_key = os.environ["SENDGRID_API_KEY"]
+    impersonate_subuser = "John Smith"
+    endpoint = "http://localhost:3000/v3/mail/send"
+    client = SendgridAPI(
+        api_key=secret_key,
+        endpoint=endpoint,
+        impersonate_subuser=impersonate_subuser,
         )
 
-        yield client
+    yield client
 
-        request("DELETE", url="http://localhost:3000/api/mails")
+    request("DELETE", url="http://localhost:3000/api/mails")
 
-    @pytest.fixture()
-    def email(self) -> Mail:
-        email = Mail(
-            from_email="johndoe@example.com",
-            to_emails="mahndoe@example.com",
-            subject="Example email",
-            plain_text_content="Hello World!",
-        )
-        return email
+@pytest.fixture
+def email() -> Mail:
+    email = Mail(
+        from_email="johndoe@example.com",
+        to_emails="mahndoe@example.com",
+        subject="Example email",
+        plain_text_content="Hello World!",
+    )
+    return email
 
-    @pytest.fixture
-    def messages_received(self):
+@pytest.fixture
+def messages_received():
         response = request("GET", url="http://localhost:3000/api/mails")
         return response.json()
 
-    @pytest.mark.asyncio
-    async def test_post_status(self, client: SendgridAPI, email: Mail) -> None:
-        """
-        Test the status code of the POST request.
+@pytest.mark.asyncio
+async def test_post_status(client: SendgridAPI, email: Mail) -> None:
+    """
+    Test the status code of the POST request.
 
-        Args:
-            email (Mail): The email object to be sent.
+    Args:
+        email (Mail): The email object to be sent.
+    Returns:
+        None
+    Raises:
+        AssertionError: If the response status code is not 202.
+    """
+    async with client:
+        response = await client.send(email)
 
-        Returns:
-            None
+    assert response.status_code == 202
 
-        Raises:
-            AssertionError: If the response status code is not 202.
-        """
-        async with client:
-            response = await client.send(email)
-
-        assert response.status_code == 202
-
-    @pytest.mark.asyncio
-    async def test_session_closed_exception(self, client: SendgridAPI, email: Mail) -> None:
-        """
-        Test that the SessionClosedException is raised when the session is closed.
-        """
-        async with client:
-
-            assert client.session
-            await client.session.aclose()
-            assert client.session.is_closed
-    
-            with pytest.raises(SessionClosedException):
-                await client.send(email)
-
-    @pytest.mark.asyncio
-    async def test_if_messages_sent_are_correct(self, client: SendgridAPI, email: Mail) -> None:
-        """
-        Test if the sent messages are valid.
-
-        Args:
-            email (Mail): The email message to be sent.
-
-        Returns:
-            None
-        """
-        async with client:
+@pytest.mark.asyncio
+async def test_session_closed_exception(client: SendgridAPI, email: Mail) -> None:
+    """
+    Test that the SessionClosedException is raised when the session is closed.
+    """
+    async with client:
+        assert client.session
+        await client.session.aclose()
+        assert client.session.is_closed
+        with pytest.raises(SessionClosedException):
             await client.send(email)
 
-        response = request("GET", url="http://localhost:3000/api/mails")
-        messages = response.json()
+@pytest.mark.asyncio
+async def test_if_messages_sent_are_correct(client: SendgridAPI, email: Mail) -> None:
+    """
+    Test if the sent messages are valid.
+    Args:
+        email (Mail): The email message to be sent.
+    Returns:
+        None
+    """
+    async with client:
+        await client.send(email)
 
-        assert len(messages) == 1
-        msg = messages[0]
+    response = request("GET", url="http://localhost:3000/api/mails")
+    messages = response.json()
 
-        assert msg["from"] == {"email": "johndoe@example.com"}
-        assert msg["subject"] == "Example email"
-        assert msg["personalizations"] == [
-            {"to": [{"email": "mahndoe@example.com"}]}
-        ]
-        assert msg["content"] == [
-            {"type": "text/plain", "value": "Hello World!"}
-        ]
+    assert len(messages) == 1
+
+    msg = messages[0]
+
+    assert msg["from"] == {"email": "johndoe@example.com"}
+    assert msg["subject"] == "Example email"
+    assert msg["personalizations"] == [
+        {"to": [{"email": "mahndoe@example.com"}]}
+    ]
+    assert msg["content"] == [
+        {"type": "text/plain", "value": "Hello World!"}
+    ]

--- a/tests/integration/test_sendgrid_client_integration.py
+++ b/tests/integration/test_sendgrid_client_integration.py
@@ -1,4 +1,5 @@
 import os
+
 import pytest
 from httpx import request
 from sendgrid import Mail  # type: ignore
@@ -16,12 +17,13 @@ def client():
     client = SendgridAPI(
         api_key=secret_key,
         endpoint=endpoint,
-        impersonate_subuser=impersonate_subuser
+        impersonate_subuser=impersonate_subuser,
     )
 
     yield client
 
     request("DELETE", url="http://localhost:3000/api/mails")
+
 
 @pytest.fixture
 def email() -> Mail:
@@ -33,10 +35,12 @@ def email() -> Mail:
     )
     return email
 
+
 @pytest.fixture
 def messages_received():
-        response = request("GET", url="http://localhost:3000/api/mails")
-        return response.json()
+    response = request("GET", url="http://localhost:3000/api/mails")
+    return response.json()
+
 
 @pytest.mark.asyncio
 async def test_post_status(client: SendgridAPI, email: Mail) -> None:
@@ -55,8 +59,11 @@ async def test_post_status(client: SendgridAPI, email: Mail) -> None:
 
     assert response.status_code == 202
 
+
 @pytest.mark.asyncio
-async def test_session_closed_exception(client: SendgridAPI, email: Mail) -> None:
+async def test_session_closed_exception(
+    client: SendgridAPI, email: Mail
+) -> None:
     """
     Test that the SessionClosedException is raised when the session is closed.
     """
@@ -67,8 +74,11 @@ async def test_session_closed_exception(client: SendgridAPI, email: Mail) -> Non
         with pytest.raises(SessionClosedException):
             await client.send(email)
 
+
 @pytest.mark.asyncio
-async def test_if_messages_sent_are_correct(client: SendgridAPI, email: Mail) -> None:
+async def test_if_messages_sent_are_correct(
+    client: SendgridAPI, email: Mail
+) -> None:
     """
     Test if the sent messages are valid.
     Args:
@@ -91,6 +101,4 @@ async def test_if_messages_sent_are_correct(client: SendgridAPI, email: Mail) ->
     assert msg["personalizations"] == [
         {"to": [{"email": "mahndoe@example.com"}]}
     ]
-    assert msg["content"] == [
-        {"type": "text/plain", "value": "Hello World!"}
-    ]
+    assert msg["content"] == [{"type": "text/plain", "value": "Hello World!"}]

--- a/tests/integration/test_sendgrid_client_integration.py
+++ b/tests/integration/test_sendgrid_client_integration.py
@@ -16,7 +16,8 @@ def client():
     client = SendgridAPI(
         api_key=secret_key,
         endpoint=endpoint,
-        impersonate_subuser=impersonate_subuser,
+        impersonate_subuser=impersonate_subuser
+    )
 
     yield client
 

--- a/tests/unit/test_sendgrid_client.py
+++ b/tests/unit/test_sendgrid_client.py
@@ -26,3 +26,23 @@ def test_constructor(client: SendgridAPI) -> None:
         "Content-Type": "application/json",
         "On-Behalf-Of": "John Smith",
     }
+
+
+def test_str(client: SendgridAPI) -> None:
+    """
+    Test __str__ method.
+    """
+    assert (
+        str(client)
+        == "SendGrid API Client\n  • Endpoint: https://api.sendgrid.com/v3/mail/send\n"
+    )
+
+
+def test_repr(client: SendgridAPI) -> None:
+    """
+    Test __repr__ method.
+    """
+    assert (
+        repr(client)
+        == "SendgridAPI(endpoint=https://api.sendgrid.com/v3/mail/send)"
+    )

--- a/tests/unit/test_sendgrid_client.py
+++ b/tests/unit/test_sendgrid_client.py
@@ -2,28 +2,25 @@ import pytest
 
 from async_sendgrid.sendgrid import SendgridAPI
 
+@pytest.fixture
+def client() -> SendgridAPI:
+    secret_key = "SECRET_KEY"
+    impersonate_subuser = "John Smith"
+    client = SendgridAPI(
+        api_key=secret_key, impersonate_subuser=impersonate_subuser
+    )
+    return client
 
-class TestAsyncClient:
-    @pytest.fixture(autouse=True)
-    def _setup(self) -> None:
-        secret_key = "SECRET_KEY"
-        impersonate_subuser = "John Smith"
-        self._service = SendgridAPI(
-            api_key=secret_key, impersonate_subuser=impersonate_subuser
-        )
-
-    def test_constructor(self) -> None:
-        """
-        Test constructor.
-        """
-        assert (
-            self._service.endpoint == "https://api.sendgrid.com/v3/mail/send"
-        )
-        assert self._service.api_key == "SECRET_KEY"
-        assert self._service.headers == {
-            "Authorization": "Bearer SECRET_KEY",
-            "User-Agent": "sendgrid-async;python",
-            "Accept": "*/*",
-            "Content-Type": "application/json",
-            "On-Behalf-Of": "John Smith",
-        }
+def test_constructor(client: SendgridAPI) -> None:
+    """
+    Test constructor.
+    """
+    assert client.endpoint == "https://api.sendgrid.com/v3/mail/send"
+    assert client.api_key == "SECRET_KEY"
+    assert client.headers == {
+        "Authorization": "Bearer SECRET_KEY",
+        "User-Agent": "sendgrid-async;python",
+        "Accept": "*/*",
+        "Content-Type": "application/json",
+        "On-Behalf-Of": "John Smith",
+    }

--- a/tests/unit/test_sendgrid_client.py
+++ b/tests/unit/test_sendgrid_client.py
@@ -2,6 +2,7 @@ import pytest
 
 from async_sendgrid.sendgrid import SendgridAPI
 
+
 @pytest.fixture
 def client() -> SendgridAPI:
     secret_key = "SECRET_KEY"
@@ -10,6 +11,7 @@ def client() -> SendgridAPI:
         api_key=secret_key, impersonate_subuser=impersonate_subuser
     )
     return client
+
 
 def test_constructor(client: SendgridAPI) -> None:
     """


### PR DESCRIPTION
This pull request introduces a new exception handling mechanism for closed sessions in the `async_sendgrid` library, along with corresponding updates to the integration tests. The key changes include the addition of a custom exception, updates to the `SendgridAPI` class to handle session closures, and new test cases to validate this behavior.

### Exception Handling Enhancements:
* Added a new `SessionClosedException` in `async_sendgrid/exception.py` to handle cases where the session is unexpectedly closed.
* Updated the `SendgridAPI` class in `async_sendgrid/sendgrid.py` to raise `SessionClosedException` if the session is closed during a `send` operation.
* Introduced a `session` property in `SendgridAPI` to provide access to the underlying session object.

### Integration Test Updates:
* Refactored the test setup in `tests/integration/test_sendgrid_client_integration.py` to use a `client` fixture instead of a class-level `_service` attribute.
* Added a new test case, `test_session_closed_exception`, to ensure that `SessionClosedException` is raised when attempting to send an email after the session is closed.
* Updated existing test cases to use the `client` fixture and ensure compatibility with the new session handling logic. [[1]](diffhunk://#diff-20d12a87be47c7191716319628ade21407398051833c057e7080fb2e341ae01cL42-R44) [[2]](diffhunk://#diff-20d12a87be47c7191716319628ade21407398051833c057e7080fb2e341ae01cL71-R87)